### PR TITLE
Custom linter fixes nomock

### DIFF
--- a/pkg/golinters/goanalysis/linter_test.go
+++ b/pkg/golinters/goanalysis/linter_test.go
@@ -188,6 +188,34 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 			},
 		},
 		{
+			name: "Shows issue when suggested edits exist but has no TextEdits",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message:   "fix something",
+								TextEdits: []analysis.TextEdit{},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+				linterName: "some-linter",
+			},
+			wantIssues: []result.Issue{
+				{
+					FromLinter: "some-linter",
+					Text:       "some-analyzer: failure message",
+				},
+			},
+		},
+		{
 			name: "Replace Whole Line",
 			args: args{
 				diag:       &MockedIDiagnostic{},
@@ -277,7 +305,6 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				m.On("getPositionOf", posEquals(151)).Return(token.Position{Line: 5, Column: 10})
 			},
 		},
-		// TODO: TDD 1 suggested fix, no text edits!
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/golinters/goanalysis/linter_test.go
+++ b/pkg/golinters/goanalysis/linter_test.go
@@ -130,15 +130,15 @@ func posEquals(expected token.Pos) interface{} {
 	})
 }
 
-func Test_getIssuesForDiagnostic(t *testing.T) {
+func Test_buildSingleIssue(t *testing.T) {
 	type args struct {
 		diag       iDiagnostic
 		linterName string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantIssues []result.Issue
+		name      string
+		args      args
+		wantIssue result.Issue
 
 		prepare func(m *MockedIDiagnostic)
 	}{
@@ -158,11 +158,9 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 
 				linterName: "some-linter",
 			},
-			wantIssues: []result.Issue{
-				{
-					FromLinter: "some-linter",
-					Text:       "failure message",
-				},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "failure message",
 			},
 		},
 		{
@@ -180,11 +178,9 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				},
 				linterName: "some-linter",
 			},
-			wantIssues: []result.Issue{
-				{
-					FromLinter: "some-linter",
-					Text:       "some-analyzer: failure message",
-				},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
 			},
 		},
 		{
@@ -208,11 +204,9 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				},
 				linterName: "some-linter",
 			},
-			wantIssues: []result.Issue{
-				{
-					FromLinter: "some-linter",
-					Text:       "some-analyzer: failure message",
-				},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
 			},
 		},
 		{
@@ -221,19 +215,17 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				diag:       &MockedIDiagnostic{},
 				linterName: "some-linter",
 			},
-			wantIssues: []result.Issue{
-				{
-					FromLinter: "some-linter",
-					Text:       "some-analyzer: failure message",
-					LineRange: &result.Range{
-						From: 5,
-						To:   5,
-					},
-					Replacement: &result.Replacement{
-						NeedOnlyDelete: false,
-						NewLines: []string{
-							"// Some comment to fix",
-						},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
+				LineRange: &result.Range{
+					From: 5,
+					To:   5,
+				},
+				Replacement: &result.Replacement{
+					NeedOnlyDelete: false,
+					NewLines: []string{
+						"// Some comment to fix",
 					},
 				},
 			},
@@ -271,11 +263,9 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				diag:       &MockedIDiagnostic{},
 				linterName: "some-linter",
 			},
-			wantIssues: []result.Issue{
-				{
-					FromLinter: "some-linter",
-					Text:       "some-analyzer: failure message",
-				},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
 			},
 			prepare: func(m *MockedIDiagnostic) {
 				d := &Diagnostic{
@@ -313,8 +303,8 @@ func Test_getIssuesForDiagnostic(t *testing.T) {
 				tt.prepare(diagnostic)
 			}
 
-			if gotIssues := getIssuesForDiagnostic(tt.args.diag, tt.args.linterName); !reflect.DeepEqual(gotIssues, tt.wantIssues) {
-				t.Errorf("getIssuesForDiagnostic() = %v, want %v", gotIssues, tt.wantIssues)
+			if gotIssues := buildSingleIssue(tt.args.diag, tt.args.linterName); !reflect.DeepEqual(gotIssues, tt.wantIssue) {
+				t.Errorf("buildSingleIssue() = %v, want %v", gotIssues, tt.wantIssue)
 			}
 		})
 	}

--- a/pkg/golinters/goanalysis/linter_test.go
+++ b/pkg/golinters/goanalysis/linter_test.go
@@ -57,6 +57,18 @@ func Test_buildIssues(t *testing.T) {
 		diags             []Diagnostic
 		linterNameBuilder func(diag *Diagnostic) string
 	}
+	basicFixes := []analysis.SuggestedFix{
+		{
+			Message: "Basic",
+			TextEdits: []analysis.TextEdit{
+				{
+					Pos:     0,
+					End:     0,
+					NewText: []byte("// Add comment to first line"),
+				},
+			},
+		},
+	}
 	tests := []struct {
 		name string
 		args args
@@ -121,6 +133,40 @@ func Test_buildIssues(t *testing.T) {
 				{
 					FromLinter: "some-linter",
 					Text:       "some-analyzer: failure message",
+				},
+			},
+		},
+		{
+			name: "Has basic suggested fix",
+			args: args{
+				diags: []Diagnostic{
+					{
+						Diagnostic: analysis.Diagnostic{
+							Message:        "failure message",
+							SuggestedFixes: basicFixes,
+						},
+						Analyzer: &analysis.Analyzer{
+							Name: "some-analyzer",
+						},
+						Position: token.Position{},
+						Pkg:      nil,
+					},
+				},
+				linterNameBuilder: func(*Diagnostic) string {
+					return "some-linter"
+				},
+			},
+			want: []result.Issue{
+				{
+					FromLinter: "some-linter",
+					Text:       "some-analyzer: failure message",
+					Replacement: &result.Replacement{
+						NeedOnlyDelete: false,
+						NewLines: []string{
+							"// Add comment to first line",
+							"",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Local PR, NOT to upstream.

Allows tools/analysis based linters (specifically custom linters) to pass a suggested fix from a diagnostic (linting error) back to the fixer for usage with the `-fix` flag if:
- There is one `SuggestedFix` (more is fine, but only the first will be observed)
- There is only and exactly one `TextEdit` (to avoid applying partial fixes)
- The fix MUST replace one or more lines of text in the source document with 0 or more lines of text, to abide by the line replacement mechanisms in the fixer.